### PR TITLE
Student Ranks

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,15 @@ To check if tests are passing, run `python ./manage.py test`
         "teacher": 1,   
         "id": 1,   
         "first_name": "newStudent1First",   
-        "last_name": "newStudent1Last"
+        "last_name": "newStudent1Last",
+        "class_rank": 1
     },   
     {   
         "teacher": 1,   
         "id": 2,   
         "first_name": "newStudent2First",   
-        "last_name": "newStudent2Last"
+        "last_name": "newStudent2Last",
+        "class_rank": 2
     }   
   ]     
  ```

--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,7 @@
+from django.db.models.functions import Rank, RowNumber
+from django.db.models.expressions import Window
 from django.db import models
-from django.db.models import Avg
+from django.db.models import Avg, F
 
 class Teacher(models.Model):
   first_name = models.CharField(max_length=30)
@@ -27,9 +29,12 @@ class Student(models.Model):
     return str(f'{self.first_name} {self.last_name}')
 
   def ranked_by_average_score(teacher_id):
-    return Student.objects.filter(teacher_id=teacher_id).annotate(average_score=Avg('lessonstudent__score')).order_by('-average_score')
-
-
+    return Student.objects.filter(teacher_id=teacher_id).annotate(
+      average_score=Avg('lessonstudent__score'), 
+      class_rank=Window(expression=Rank(), 
+      order_by=F('average_score').desc())).order_by('-average_score')
+    
+    
 class Lesson(models.Model):
   name = models.CharField(max_length=100)
   description = models.CharField(max_length=100)

--- a/api/models.py
+++ b/api/models.py
@@ -1,4 +1,4 @@
-from django.db.models.functions import Rank, RowNumber
+from django.db.models.functions import RowNumber
 from django.db.models.expressions import Window
 from django.db import models
 from django.db.models import Avg, F

--- a/api/models.py
+++ b/api/models.py
@@ -26,8 +26,8 @@ class Student(models.Model):
   def full_name(self):
     return str(f'{self.first_name} {self.last_name}')
 
-  def ranked_by_average_score():
-    return Student.objects.annotate(average_score=Avg('lessonstudent__score')).order_by('-average_score')
+  def ranked_by_average_score(teacher_id):
+    return Student.objects.filter(teacher_id=teacher_id).annotate(average_score=Avg('lessonstudent__score')).order_by('-average_score')
 
 
 class Lesson(models.Model):

--- a/api/models.py
+++ b/api/models.py
@@ -32,8 +32,8 @@ class Student(models.Model):
     return Student.objects.filter(teacher_id=teacher_id).annotate(
       average_score=Avg('lessonstudent__score'), 
       class_rank=Window(expression=RowNumber(), 
-      order_by=F('average_score').desc())).order_by('-average_score')
-    
+      order_by=F('average_score').desc())).order_by(F('average_score').desc(nulls_last=True))
+
 
 class Lesson(models.Model):
   name = models.CharField(max_length=100)

--- a/api/models.py
+++ b/api/models.py
@@ -31,10 +31,10 @@ class Student(models.Model):
   def ranked_by_average_score(teacher_id):
     return Student.objects.filter(teacher_id=teacher_id).annotate(
       average_score=Avg('lessonstudent__score'), 
-      class_rank=Window(expression=Rank(), 
+      class_rank=Window(expression=RowNumber(), 
       order_by=F('average_score').desc())).order_by('-average_score')
     
-    
+
 class Lesson(models.Model):
   name = models.CharField(max_length=100)
   description = models.CharField(max_length=100)

--- a/api/models.py
+++ b/api/models.py
@@ -26,6 +26,10 @@ class Student(models.Model):
   def full_name(self):
     return str(f'{self.first_name} {self.last_name}')
 
+  def ranked_by_average_score():
+    return Student.objects.annotate(average_score=Avg('lessonstudent__score')).order_by('-average_score')
+
+
 class Lesson(models.Model):
   name = models.CharField(max_length=100)
   description = models.CharField(max_length=100)
@@ -73,3 +77,4 @@ class Answer(models.Model):
 
   def __str__(self):
     return self.answer
+

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -17,6 +17,18 @@ class StudentSerializer(serializers.ModelSerializer):
         'teacher', 'id', 'first_name', 'last_name'
     )
 
+class StudentRankSerializer(serializers.ModelSerializer):
+  class_rank = serializers.SerializerMethodField()
+  class Meta:
+    model = Student
+    fields = (
+        'teacher', 'id', 'first_name', 'last_name', 'class_rank'
+    )
+
+  def get_class_rank(self, obj):
+    return obj.class_rank
+
+
 class AnswerSerializer(serializers.ModelSerializer):
   class Meta:
     model = Answer

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -83,8 +83,8 @@ class LessonStudentModelTest(TestCase):
     self.answer7 = self.question4.answer_set.create(answer='answer3', correct=True)
     self.answer8 = self.question4.answer_set.create(answer='answer4', correct=False)
 
-    self.student1 = StudentFactory()
-    self.student2 = StudentFactory()
+    self.student1 = StudentFactory(teacher=self.teacher1)
+    self.student2 = StudentFactory(teacher=self.teacher1)
 
     self.lessonStudent1 = self.student1.lessonstudent_set.create(lesson_id=self.lesson1.id, mood='cranky', score=90)
     self.lessonStudent2 = self.student1.lessonstudent_set.create(lesson_id=self.lesson2.id, mood='cranky', score=96)

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -103,4 +103,11 @@ class LessonStudentModelTest(TestCase):
 
     self.assertEqual(score, 76.0)
 
+  def test_student_average_score(self):
+    students = Student.ranked_by_average_score()
+
+    expected_students = [self.student1, self.student2]
+
+    self.assertEqual(students, expected_students)
+
 

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -103,7 +103,7 @@ class LessonStudentModelTest(TestCase):
     self.assertEqual(score, 76.0)
 
   def test_student_average_score(self):
-    students = Student.ranked_by_average_score()
+    students = Student.ranked_by_average_score(self.teacher1.id)
 
     expected_students = ["<Student: %s %s>" % (self.student1.first_name, self.student1.last_name), "<Student: %s %s>" % (self.student2.first_name, self.student2.last_name)]
 

--- a/api/tests/test_models.py
+++ b/api/tests/test_models.py
@@ -85,7 +85,6 @@ class LessonStudentModelTest(TestCase):
 
     self.student1 = StudentFactory()
     self.student2 = StudentFactory()
-    self.student3 = StudentFactory()
 
     self.lessonStudent1 = self.student1.lessonstudent_set.create(lesson_id=self.lesson1.id, mood='cranky', score=90)
     self.lessonStudent2 = self.student1.lessonstudent_set.create(lesson_id=self.lesson2.id, mood='cranky', score=96)
@@ -106,8 +105,8 @@ class LessonStudentModelTest(TestCase):
   def test_student_average_score(self):
     students = Student.ranked_by_average_score()
 
-    expected_students = [self.student1, self.student2]
+    expected_students = ["<Student: %s %s>" % (self.student1.first_name, self.student1.last_name), "<Student: %s %s>" % (self.student2.first_name, self.student2.last_name)]
 
-    self.assertEqual(students, expected_students)
+    self.assertQuerysetEqual(students, expected_students)
 
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -201,9 +201,9 @@ class StatisticsSet(TestCase):
     self.answer7 = self.question4.answer_set.create(answer='answer3', correct=True)
     self.answer8 = self.question4.answer_set.create(answer='answer4', correct=False)
 
-    self.student1 = StudentFactory()
-    self.student2 = StudentFactory()
-    self.student3 = StudentFactory()
+    self.student1 = StudentFactory(teacher=self.teacher1)
+    self.student2 = StudentFactory(teacher=self.teacher1)
+    self.student3 = StudentFactory(teacher=self.teacher1)
 
     self.lessonStudent1 = self.student1.lessonstudent_set.create(lesson_id=self.lesson1.id, mood='cranky', score=90)
     self.lessonStudent2 = self.student1.lessonstudent_set.create(lesson_id=self.lesson2.id, mood='cranky', score=96)
@@ -250,9 +250,7 @@ class StatisticsSet(TestCase):
     self.assertIsInstance(response.data[2]["zscore"], float)
 
   def test_get_student_rank_for_all_students(self):
-    response = self.client.get('api/v1/teachers/%s/students/' % self.teacher1.id)
-
-    import code; code.interact(local=dict(globals(), **locals()))
+    response = self.client.get('/api/v1/teachers/%s/students/' % self.teacher1.id)
 
     self.assertEqual(response.data[0]['rank'], 1)
     self.assertEqual(response.data[1]['rank'], 1)

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -204,6 +204,7 @@ class StatisticsSet(TestCase):
     self.student1 = StudentFactory(teacher=self.teacher1)
     self.student2 = StudentFactory(teacher=self.teacher1)
     self.student3 = StudentFactory(teacher=self.teacher1)
+    self.student4 = StudentFactory(teacher=self.teacher1)
 
     self.lessonStudent1 = self.student1.lessonstudent_set.create(lesson_id=self.lesson1.id, mood='cranky', score=90)
     self.lessonStudent2 = self.student1.lessonstudent_set.create(lesson_id=self.lesson2.id, mood='cranky', score=96)

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -252,8 +252,9 @@ class StatisticsSet(TestCase):
   def test_get_student_rank_for_all_students(self):
     response = self.client.get('/api/v1/teachers/%s/students/' % self.teacher1.id)
 
-    self.assertEqual(response.data[0]['rank'], 1)
-    self.assertEqual(response.data[1]['rank'], 1)
+    self.assertIsInstance(response.data[0]['class_rank'], int)
+    self.assertIsInstance(response.data[1]['class_rank'], int)
+    self.assertIsInstance(response.data[2]['class_rank'], int)
 
 
 class StudentLessonViewSet(TestCase):

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -249,6 +249,15 @@ class StatisticsSet(TestCase):
     self.assertIsNotNone(response.data[2]["student_id"])
     self.assertIsInstance(response.data[2]["zscore"], float)
 
+  def test_get_student_rank_for_all_students(self):
+    response = self.client.get('api/v1/teachers/%s/students/' % self.teacher1.id)
+
+    import code; code.interact(local=dict(globals(), **locals()))
+
+    self.assertEqual(response.data[0]['rank'], 1)
+    self.assertEqual(response.data[1]['rank'], 1)
+
+
 class StudentLessonViewSet(TestCase):
   def setUp(self):
     self.teacher = Teacher.objects.create(first_name='Severus', last_name='Snape')

--- a/api/views.py
+++ b/api/views.py
@@ -10,7 +10,7 @@ from django.db.models import Avg
 
 from api.models import Teacher, Lesson, LessonStudent, Student
 from api.popos import StudentScore, LessonScore, ZScore, ZScoreGenerator
-from api.serializers import TeacherSerializer, LessonSerializer, LessonStudentSerializer, StudentSerializer, StudentScoreSerializer, LessonScoreSerializer, ZScoreSerializer
+from api.serializers import TeacherSerializer, LessonSerializer, LessonStudentSerializer, StudentSerializer, StudentScoreSerializer, LessonScoreSerializer, ZScoreSerializer, StudentRankSerializer
 
 from . import watson_service
 
@@ -32,7 +32,7 @@ class TeacherStudent(APIView):
   def get(self, request, pk):
     students = Student.ranked_by_average_score(pk)
 
-    return Response(StudentSerializer(students, many=True).data)
+    return Response(StudentRankSerializer(students, many=True).data)
 
   def post(self, request, pk):
     teacher = Teacher.objects.get(pk=pk)

--- a/api/views.py
+++ b/api/views.py
@@ -31,7 +31,6 @@ class TeacherStudent(APIView):
 
   def get(self, request, pk):
     students = Student.ranked_by_average_score(pk)
-
     return Response(StudentRankSerializer(students, many=True).data)
 
   def post(self, request, pk):

--- a/api/views.py
+++ b/api/views.py
@@ -30,8 +30,9 @@ class TeacherStudent(APIView):
   parser_classes=[JSONParser]
 
   def get(self, request, pk):
-    teacher = Teacher.objects.get(pk=pk)
-    return Response(StudentSerializer(teacher.student_set, many=True).data)
+    students = Student.ranked_by_average_score(pk)
+
+    return Response(StudentSerializer(students, many=True).data)
 
   def post(self, request, pk):
     teacher = Teacher.objects.get(pk=pk)


### PR DESCRIPTION
## Description
Modify the existing GET `api/v1/teachers/:teacher_id/students/` endpoint to accomplish two things things:
  - Students are now returned in order by their total average score. Students with the highest average are returned first.
  - A class rank is now included in the response. The student with the highest class average is 1.

Completes User Story #36 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## RSpec Results
- 100%
